### PR TITLE
Include the note about required `fontcustom` bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ var app = new EmberApp({
   }
 });
 ```
+
+### Note
+
+You must have installed `fontcustom` to be able to use this addon. Check installation guide [there](https://github.com/FontCustom/fontcustom).


### PR DESCRIPTION
If you do not have `fontcustom` binary, the process fail with a `ENOENT` error with not much more information to identify the problem. Worst, it doesn't even tell you that it is this addon failing.

So I thought adding the requirement in the `README` for others would be more than helpful ;-)
