### PR TITLE
use broccoli-fontcustom with cross-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "broccoli-fontcustom": "Kinvey/broccoli-fontcustom#addon-refactor",
+    "broccoli-fontcustom": "miguelcobain/broccoli-fontcustom#cross-spawn",
     "broccoli-merge-trees": "^0.2.1"
   }
 }


### PR DESCRIPTION
This would really help windows folks.
Basically, miguelcobain/broccoli-fontcustom#cross-spawn is a version of broccoli-fontcustom that uses cross-spawn. This is a cross-platform way to spawn processes.
