### PR TITLE
Respect rootURL when rendering stylesheet link in head.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ module.exports = {
     this._super.included.apply(this, arguments);
   },
 
-  contentFor: function(type) {
+  contentFor: function(type, config) {
     if (type === 'head') {
-      return '<link rel="stylesheet" href="assets/icons.css">';
+      return `<link rel="stylesheet" href="${config.rootURL}assets/icons.css">`;
     }
   },
 


### PR DESCRIPTION
Thanks for addon! I noticed the contentFor block isn't using `config.rootURL` when spitting out the path to icons.css. Needed for non-standard ember root paths.

Relevant [ember-cli docs](https://ember-cli.com/user-guide/#history-api-and-root-url).
